### PR TITLE
Add Unreal project skeleton for Wizard War I

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ prompts = get_prompts('es')
 ```
 
 The default language is English if an unknown code is provided.
+
+## Wizard War I Skeleton
+
+A minimal Unreal Engine project is available in the `WizardWarI` directory. It provides starter source files for a 1-on-1 spell combat game with Xbox controller support. See `WizardWarI/README.md` for build instructions.

--- a/WizardWarI/README.md
+++ b/WizardWarI/README.md
@@ -1,0 +1,28 @@
+# Wizard War I (WWI)
+
+This directory contains a minimal skeleton for an Unreal Engine project. It does not include game assets or full gameplay logic, but provides starting source files for building the 1-on-1 spell combat game described in the repository.
+
+## Overview
+
+* Players chain `Power`, `Area`, and `Effect` tokens to cast spells.
+* Each arm can hold a chain of tokens for dual wielding.
+* Tokens are acquired through combat and target practice.
+* Character creation and local multiplayer are planned features.
+
+## Building
+
+1. Install Unreal Engine 5 (or later) from the Epic Games Launcher.
+2. Clone this repository and open `WizardWarI.uproject` in the Unreal Editor.
+3. Use `File > Generate Visual Studio project files` if needed.
+4. Build the project from the editor or via command line:
+   ```sh
+   /path/to/UnrealEngine/Engine/Build/BatchFiles/RunUAT.sh \
+     BuildCookRun -project="$(pwd)/WizardWarI.uproject" \
+     -noP4 -platform=Win64 -clientconfig=Development \
+     -cook -allmaps -build -stage -pak -archive -archivedirectory="Build"
+   ```
+5. The packaged game will appear in the `Build` directory.
+
+## Note
+
+Compilation requires Unreal Engine which is not included in this repository. The project is provided as a starting template only.

--- a/WizardWarI/Source/WizardWarI/Token.cpp
+++ b/WizardWarI/Source/WizardWarI/Token.cpp
@@ -1,0 +1,1 @@
+#include "Token.h"

--- a/WizardWarI/Source/WizardWarI/Token.h
+++ b/WizardWarI/Source/WizardWarI/Token.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "CoreMinimal.h"
+#include "UObject/NoExportTypes.h"
+#include "Token.generated.h"
+
+UENUM(BlueprintType)
+enum class ETokenType : uint8
+{
+    Power,
+    Area,
+    Effect
+};
+
+UCLASS(Blueprintable)
+class UToken : public UObject
+{
+    GENERATED_BODY()
+public:
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Token")
+    ETokenType TokenType;
+};

--- a/WizardWarI/Source/WizardWarI/WizardWarI.Build.cs
+++ b/WizardWarI/Source/WizardWarI/WizardWarI.Build.cs
@@ -1,0 +1,9 @@
+using UnrealBuildTool;
+public class WizardWarI : ModuleRules
+{
+    public WizardWarI(ReadOnlyTargetRules Target) : base(Target)
+    {
+        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore" });
+    }
+}

--- a/WizardWarI/Source/WizardWarI/WizardWarI.cpp
+++ b/WizardWarI/Source/WizardWarI/WizardWarI.cpp
@@ -1,0 +1,3 @@
+#include "WizardWarI.h"
+#include "Modules/ModuleManager.h"
+IMPLEMENT_PRIMARY_GAME_MODULE( FDefaultGameModuleImpl, WizardWarI, "WizardWarI" );

--- a/WizardWarI/Source/WizardWarI/WizardWarI.h
+++ b/WizardWarI/Source/WizardWarI/WizardWarI.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "CoreMinimal.h"

--- a/WizardWarI/Source/WizardWarI/WizardWarIGameModeBase.cpp
+++ b/WizardWarI/Source/WizardWarI/WizardWarIGameModeBase.cpp
@@ -1,0 +1,1 @@
+#include "WizardWarIGameModeBase.h"

--- a/WizardWarI/Source/WizardWarI/WizardWarIGameModeBase.h
+++ b/WizardWarI/Source/WizardWarI/WizardWarIGameModeBase.h
@@ -1,0 +1,10 @@
+#pragma once
+#include "CoreMinimal.h"
+#include "GameFramework/GameModeBase.h"
+#include "WizardWarIGameModeBase.generated.h"
+
+UCLASS()
+class AWizardWarIGameModeBase : public AGameModeBase
+{
+    GENERATED_BODY()
+};

--- a/WizardWarI/WizardWarI.uproject
+++ b/WizardWarI/WizardWarI.uproject
@@ -1,0 +1,13 @@
+{
+    "FileVersion": 3,
+    "EngineAssociation": "5.0",
+    "Category": "Games",
+    "Description": "Wizard War I - Spell combat game skeleton",
+    "Modules": [
+        {
+            "Name": "WizardWarI",
+            "Type": "Runtime",
+            "LoadingPhase": "Default"
+        }
+    ]
+}

--- a/WizardWarI/build.sh
+++ b/WizardWarI/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Example build script for Wizard War I
+# Requires Unreal Engine installed and environment variables set.
+UAT_PATH="${UE_PATH:-/path/to/UnrealEngine}/Engine/Build/BatchFiles/RunUAT.sh"
+"$UAT_PATH" BuildCookRun -project="$(pwd)/WizardWarI.uproject" -noP4 -platform=Win64 -clientconfig=Development -cook -allmaps -build -stage -pak -archive -archivedirectory="Build"


### PR DESCRIPTION
## Summary
- create WizardWarI Unreal Engine skeleton
- include build script and basic C++ modules
- document how to build the project
- reference project in main README

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68614c0445d8832e960aefd53167ddf4