### PR TITLE
Add Debian ISO build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ pip install -r requirements.txt
 python -m ai_gui.app
 ```
 
+## Linux ChatGPT Desktop Assistant
+
+An additional script integrates ChatGPT with a simple Tkinter interface that can
+be launched from any Linux desktop. Set the `OPENAI_API_KEY` environment
+variable and run:
+
+```bash
+python -m ai_gui.chatgpt_desktop
+```
+
+You may create a `.desktop` file pointing to this command so it appears in your
+application launcher.
+
 ## HTML Interface
 
 A basic web interface is provided in the `html` directory. Open `html/index.html` in a browser or serve the folder with a simple HTTP server:
@@ -190,3 +203,7 @@ A minimal Unreal Engine project is available in the `WizardWarI` directory. It p
 
 
 
+
+## Build Debian ISO with ChatGPT Assistant
+
+A helper script (`build_debian_chatgpt_iso.sh`) uses debootstrap and live-build tools to create a minimal Debian image with the ChatGPT desktop app preinstalled. Run it as root on a Debian system with `debootstrap`, `live-build`, and `xorriso` available. The resulting `chatgpt_debian.iso` boots into a simple Openbox session and automatically launches the assistant.

--- a/ai_gui/chatgpt.desktop
+++ b/ai_gui/chatgpt.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Type=Application
+Name=ChatGPT Assistant
+Exec=python3 -m ai_gui.chatgpt_desktop
+Categories=Utility;

--- a/ai_gui/chatgpt_desktop.py
+++ b/ai_gui/chatgpt_desktop.py
@@ -1,0 +1,60 @@
+import os
+import tkinter as tk
+from tkinter import scrolledtext
+
+import openai
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if not OPENAI_API_KEY:
+    raise RuntimeError("Please set the OPENAI_API_KEY environment variable")
+
+openai.api_key = OPENAI_API_KEY
+
+class ChatGPTDesktop(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("ChatGPT Desktop Assistant")
+        self.geometry("600x400")
+        self.conversation = []
+
+        self.output_box = scrolledtext.ScrolledText(self, height=15)
+        self.output_box.pack(fill=tk.BOTH, padx=5, pady=5)
+        self.output_box.insert(tk.END, "ChatGPT ready.\n")
+
+        self.input_box = scrolledtext.ScrolledText(self, height=4)
+        self.input_box.pack(fill=tk.BOTH, padx=5, pady=5)
+
+        self.send_button = tk.Button(self, text="Send", command=self.on_send)
+        self.send_button.pack(pady=5)
+
+    def on_send(self):
+        user_msg = self.input_box.get("1.0", tk.END).strip()
+        if not user_msg:
+            return
+        self.input_box.delete("1.0", tk.END)
+        self.output_box.insert(tk.END, f"You: {user_msg}\n")
+        self.conversation.append({"role": "user", "content": user_msg})
+        self.output_box.insert(tk.END, "ChatGPT: ...\n")
+        self.output_box.see(tk.END)
+        self.update()
+        try:
+            resp = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=self.conversation,
+            )
+            reply = resp["choices"][0]["message"]["content"].strip()
+        except Exception as e:
+            reply = f"Error: {e}"
+        self.output_box.delete("end-2l", "end-1l")  # remove placeholder
+        self.output_box.insert(tk.END, f"ChatGPT: {reply}\n")
+        self.output_box.see(tk.END)
+        self.conversation.append({"role": "assistant", "content": reply})
+
+
+def main():
+    app = ChatGPTDesktop()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/build_debian_chatgpt_iso.sh
+++ b/build_debian_chatgpt_iso.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+# Build a minimal Debian ISO including the ChatGPT desktop assistant.
+# Requires: debootstrap, live-build, xorriso, root privileges.
+
+if [[ $EUID -ne 0 ]]; then
+  echo "Run this script as root" >&2
+  exit 1
+fi
+
+WORKDIR=$(pwd)/debian_chatgpt
+mkdir -p "$WORKDIR"
+cd "$WORKDIR"
+
+lb config \
+  --distribution bookworm \
+  --debian-installer live \
+  --packages "python3 python3-pip openbox"
+
+# Copy the assistant into the live image
+mkdir -p config/includes.chroot/opt/chatgpt
+cp -r ../ai_gui config/includes.chroot/opt/chatgpt/
+
+# Install openai in the chroot at build time
+mkdir -p config/hooks/normal
+cat <<'HOOK' > config/hooks/normal/99-install-openai.hook.chroot
+#!/bin/sh
+set -e
+pip3 install openai
+HOOK
+chmod +x config/hooks/normal/99-install-openai.hook.chroot
+
+# Add desktop entry
+mkdir -p config/includes.chroot/usr/share/applications
+cp ../ai_gui/chatgpt.desktop config/includes.chroot/usr/share/applications/
+
+# Autostart the assistant for the live user
+mkdir -p config/includes.chroot/etc/xdg/autostart
+cp ../ai_gui/chatgpt.desktop config/includes.chroot/etc/xdg/autostart/
+
+lb build
+
+mv live-image-amd64.hybrid.iso ../chatgpt_debian.iso
+echo "ISO created at $(pwd)/../chatgpt_debian.iso"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ transformers
 torch
 Pillow
 requests
+openai


### PR DESCRIPTION
## Summary
- add a desktop entry for the ChatGPT assistant
- provide a script to build a Debian live ISO with the assistant preinstalled
- document the ISO build process in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861ed926e60832eab67a04c060ae8f7