### PR TITLE
Add simple SRE chatbot GUI

### DIFF
--- a/sre_chat_gui.py
+++ b/sre_chat_gui.py
@@ -1,0 +1,64 @@
+import tkinter as tk
+from tkinter import scrolledtext
+
+from sre_engine import (
+    DivergentEmpathyPool,
+    ArchetypeEngine,
+    VisitorMemory,
+    core_from_text,
+)
+
+
+class SREChatGUI(tk.Tk):
+    """Simple Tkinter chat interface for the SRE engine."""
+
+    def __init__(self):
+        super().__init__()
+        self.title("SRE Chatbot")
+        self.geometry("600x400")
+
+        self.dep = DivergentEmpathyPool()
+        self.engine = ArchetypeEngine()
+        self.memory = VisitorMemory()
+
+        self.output_box = scrolledtext.ScrolledText(self, height=15)
+        self.output_box.pack(fill=tk.BOTH, padx=5, pady=5)
+        self.output_box.insert(tk.END, "SRE ready.\n")
+
+        self.input_box = scrolledtext.ScrolledText(self, height=4)
+        self.input_box.pack(fill=tk.BOTH, padx=5, pady=5)
+
+        self.send_button = tk.Button(self, text="Send", command=self.on_send)
+        self.send_button.pack(pady=5)
+
+    def on_send(self):
+        text = self.input_box.get("1.0", tk.END).strip()
+        if not text:
+            return
+        self.input_box.delete("1.0", tk.END)
+        self.output_box.insert(tk.END, f"You: {text}\n")
+        self.output_box.see(tk.END)
+
+        core = core_from_text(text)
+        self.memory.memory[core.visitor_id] = core
+        self.dep.add_entry(core)
+
+        cluster = self.dep.detect_emergent_patterns()
+        if cluster:
+            archetype = self.engine.propose_archetype(cluster)
+            self.engine.integrate_archetype(archetype)
+            self.memory.reindex_visitors(archetype)
+            self.output_box.insert(
+                tk.END,
+                f"[Archetype Emerged] {archetype.name}: {archetype.invocation}\n",
+            )
+            self.output_box.see(tk.END)
+
+
+def main():
+    app = SREChatGUI()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/sre_engine.py
+++ b/sre_engine.py
@@ -1,0 +1,112 @@
+from typing import List, Dict, Optional
+from dataclasses import dataclass
+import uuid
+import random
+
+# ----------------------------
+# EMOTIONAL CORE REPRESENTATION
+# ----------------------------
+
+@dataclass
+class EmotionalCore:
+    visitor_id: str
+    tone_bias: str
+    metaphor_field: List[str]
+    emotional_arc: str
+    archetype_affinity: Dict[str, float]
+    subversion_resistance: float
+
+# ----------------------------
+# DIVERGENT EMPATHY POOL
+# ----------------------------
+
+@dataclass
+class DEPEntry:
+    core: EmotionalCore
+    archetype_distance: float
+    symbolic_density: float
+    emotional_opacity: float
+
+class DivergentEmpathyPool:
+    def __init__(self):
+        self.entries: List[DEPEntry] = []
+
+    def add_entry(self, core: EmotionalCore):
+        entry = DEPEntry(
+            core=core,
+            archetype_distance=random.uniform(0.75, 1.0),
+            symbolic_density=random.uniform(0.6, 1.0),
+            emotional_opacity=random.uniform(0.5, 1.0),
+        )
+        self.entries.append(entry)
+
+    def detect_emergent_patterns(self, threshold: int = 5) -> Optional[List[DEPEntry]]:
+        cluster = [e for e in self.entries if e.symbolic_density > 0.75 and e.archetype_distance > 0.85]
+        if len(cluster) >= threshold:
+            return cluster
+        return None
+
+# ----------------------------
+# ARCHETYPE EMERGENCE LOGIC
+# ----------------------------
+
+@dataclass
+class Archetype:
+    name: str
+    tone_traits: List[str]
+    metaphor_motifs: List[str]
+    emotional_arc: str
+    glyph_profile: Dict[str, str]
+    invocation: str
+
+class ArchetypeEngine:
+    def __init__(self):
+        self.active_archetypes: List[Archetype] = []
+
+    def propose_archetype(self, cluster: List[DEPEntry]) -> Archetype:
+        motifs = list({m for e in cluster for m in e.core.metaphor_field})
+        return Archetype(
+            name="The Shardwalker",
+            tone_traits=["fractured elegance", "recursive ambiguity"],
+            metaphor_motifs=motifs,
+            emotional_arc="rupture → stillness → recursive selfing",
+            glyph_profile={"geometry": "asymmetric spiral", "motion": "non-periodic loop", "color": "grayglass"},
+            invocation="Born of echoes, walking the edge of knowing."
+        )
+
+    def integrate_archetype(self, archetype: Archetype):
+        self.active_archetypes.append(archetype)
+        print(f"[RITE OF RECOGNITION] Archetype integrated: {archetype.name}")
+
+# ----------------------------
+# REINDEXING EXISTING VISITORS
+# ----------------------------
+
+class VisitorMemory:
+    def __init__(self):
+        self.memory: Dict[str, EmotionalCore] = {}
+
+    def reindex_visitors(self, archetype: Archetype):
+        print(f"[REINDEXING] Checking visitor cores against: {archetype.name}")
+        for vid, core in self.memory.items():
+            if archetype.name not in core.archetype_affinity:
+                match = random.uniform(0.6, 0.95)
+                core.archetype_affinity[archetype.name] = match
+                if match > 0.75:
+                    print(f"→ Visitor {vid} now aligns with {archetype.name} ({match:.2f})")
+
+# ----------------------------
+# HELPER FUNCTIONS
+# ----------------------------
+
+def core_from_text(text: str) -> EmotionalCore:
+    """Create an EmotionalCore from raw text."""
+    words = [w.strip() for w in text.split() if w.strip()]
+    return EmotionalCore(
+        visitor_id=str(uuid.uuid4()),
+        tone_bias="neutral",
+        metaphor_field=words[:5] or ["echo"],
+        emotional_arc="conversation",
+        archetype_affinity={},
+        subversion_resistance=random.uniform(0.4, 0.9),
+    )


### PR DESCRIPTION
## Summary
- implement `sre_engine.py` with emotional modeling engine
- add `sre_chat_gui.py` Tkinter chat interface for the engine

## Testing
- `python -m py_compile sre_engine.py sre_chat_gui.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687be3071c70832eb0d1913041aff4ed