### PR TITLE
Add SpeechEngine and integrate with UnifiedAI

### DIFF
--- a/tests/test_speech.py
+++ b/tests/test_speech.py
@@ -1,0 +1,74 @@
+import pytest
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from unified_ai import UnifiedAI
+from unittest.mock import AsyncMock
+
+
+def test_speech_engine_created():
+    engine = UnifiedAI()
+    assert hasattr(engine, "speech")
+    assert engine.speech.optical is engine.optical
+
+
+@pytest.mark.asyncio
+async def test_interact_sequence(monkeypatch):
+    engine = UnifiedAI()
+    call_order = []
+
+    async def aura_validate_output(text):
+        call_order.append(f"aura:{text}")
+        return True
+
+    async def analyze_emotion(text):
+        call_order.append(f"soul_analyze:{text}")
+        return "neutral"
+
+    async def reason(text):
+        call_order.append(f"brain:{text}")
+        return "memory"
+
+    async def transfer(data, target):
+        call_order.append(f"optical:{data}")
+        return True
+
+    async def craft_reply(text, emo):
+        call_order.append(f"soul_craft:{text},{emo}")
+        return "reply"
+
+    async def speech_analyze(text):
+        call_order.append(f"speech_analyze:{text}")
+        return "analysis"
+
+    async def speech_synth(analysis):
+        call_order.append(f"speech_synthesize:{analysis}")
+        return "audio"
+
+    async def speech_transmit(audio, target="SpeechOutput"):
+        call_order.append(f"speech_transmit:{audio}")
+        return True
+
+    monkeypatch.setattr(engine.aura, "validate_output", AsyncMock(side_effect=aura_validate_output))
+    monkeypatch.setattr(engine.soul, "analyze_emotion", AsyncMock(side_effect=analyze_emotion))
+    monkeypatch.setattr(engine.brain, "reason", AsyncMock(side_effect=reason))
+    monkeypatch.setattr(engine.optical, "transfer_data", AsyncMock(side_effect=transfer))
+    monkeypatch.setattr(engine.soul, "craft_reply", AsyncMock(side_effect=craft_reply))
+    monkeypatch.setattr(engine.speech, "analyze_text", AsyncMock(side_effect=speech_analyze))
+    monkeypatch.setattr(engine.speech, "synthesize_speech", AsyncMock(side_effect=speech_synth))
+    monkeypatch.setattr(engine.speech, "transmit_speech", AsyncMock(side_effect=speech_transmit))
+
+    result = await engine.interact("hi")
+
+    assert result == "reply"
+    assert call_order == [
+        "aura:hi",
+        "soul_analyze:hi",
+        "brain:hi",
+        "optical:memory",
+        "aura:memory",
+        "soul_craft:memory,neutral",
+        "speech_analyze:reply",
+        "speech_synthesize:analysis",
+        "speech_transmit:audio",
+    ]

--- a/unified_ai/__init__.py
+++ b/unified_ai/__init__.py
@@ -8,6 +8,7 @@ from .soul import SoulEngine
 from .brain import BrainEngine
 from .optical import OpticalEngine
 from .aura import AuraEngine
+from .speech import SpeechEngine
 from .network_features import NetworkFeatureManager, NETWORK_FEATURES
 
 
@@ -22,6 +23,7 @@ class UnifiedAI:
         self.brain = BrainEngine()
         self.optical = OpticalEngine(self.redis, self.feature_manager)
         self.aura = AuraEngine()
+        self.speech = SpeechEngine(self.optical)
         self.logger = logging.getLogger(self.__class__.__name__)
         self.bg_tasks: list[asyncio.Task] = []
 
@@ -53,9 +55,13 @@ class UnifiedAI:
         emotion = await self.soul.analyze_emotion(text)
         memory_response = await self.brain.reason(text)
         await self.optical.transfer_data(memory_response, "UnifiedAI")
-        if await self.aura.validate_output(memory_response):
-            return await self.soul.craft_reply(memory_response, emotion)
-        return "Output blocked due to ethics rules"
+        if not await self.aura.validate_output(memory_response):
+            return "Output blocked due to ethics rules"
+        reply = await self.soul.craft_reply(memory_response, emotion)
+        analysis = await self.speech.analyze_text(reply)
+        speech_data = await self.speech.synthesize_speech(analysis)
+        await self.speech.transmit_speech(speech_data)
+        return reply
 
     async def _listener(self) -> None:
         async for message in self.optical.subscribe("UnifiedAI"):

--- a/unified_ai/speech.py
+++ b/unified_ai/speech.py
@@ -1,0 +1,23 @@
+import logging
+
+from .optical import OpticalEngine
+
+
+class SpeechEngine:
+    """Simple speech processing engine."""
+
+    def __init__(self, optical: OpticalEngine) -> None:
+        self.optical = optical
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    async def analyze_text(self, text: str) -> str:
+        """Perform lightweight text analysis before synthesis."""
+        return text.lower()
+
+    async def synthesize_speech(self, analysis: str) -> str:
+        """Placeholder speech synthesis step."""
+        return f"speech({analysis})"
+
+    async def transmit_speech(self, audio: str, target: str = "SpeechOutput") -> bool:
+        """Transmit synthesized speech through the OpticalEngine."""
+        return await self.optical.transfer_data(audio, target)


### PR DESCRIPTION
## Summary
- implement `SpeechEngine` with text analysis, synthesis and transmission via `OpticalEngine`
- wire `SpeechEngine` into `UnifiedAI.interact`
- add tests covering engine instantiation and interaction call order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ef0c0a02c832ebea4672568552272