### PR TITLE
Implement SystemReplicator

### DIFF
--- a/UnifiedAI.md
+++ b/UnifiedAI.md
@@ -57,6 +57,20 @@ The orchestrator coordinates these engines so that input flows through AuraEngin
 
 The request is processed asynchronously. The reply contains an empathetic acknowledgement, demonstrates memory use and the message is published to Redis.
 
+## System Replicator
+
+UnifiedAI can duplicate itself using the `SystemReplicator` utility. Launching
+`python -m unified_ai.replicator` spawns a local copy of the running engine.
+Provide `--remote <channel>` to send the state to a remote listener via the
+`OpticalEngine`.
+
+```bash
+python -m unified_ai.replicator --remote replica_channel
+```
+
+An authentication token and optional encryption key may be supplied to secure
+the transfer.
+
 ## API Endpoints
 
 - `POST /query` – send a user query and receive the AI's response.

--- a/tests/replicator_test.py
+++ b/tests/replicator_test.py
@@ -1,0 +1,56 @@
+import pytest
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from unified_ai.replicator import SystemReplicator
+from unified_ai import UnifiedAI
+
+
+@pytest.mark.asyncio
+async def test_duplicate_local_invokes_store(monkeypatch):
+    engine = UnifiedAI()
+    engine.connect = AsyncMock()
+    engine.initialize = AsyncMock()
+    engine.optical.transfer_data = AsyncMock()
+    # snapshot to return one memory and feature
+    async def fake_snapshot(self):
+        return {"memories": [{"key": "k", "content": "v"}], "features": ["feat"]}
+
+    monkeypatch.setattr(SystemReplicator, "_snapshot", fake_snapshot)
+
+    duplicate = AsyncMock()
+    duplicate.connect = AsyncMock()
+    duplicate.initialize = AsyncMock()
+    duplicate.brain.store_memory = AsyncMock()
+    from unittest.mock import MagicMock
+    duplicate.feature_manager.enable = MagicMock()
+    # patch UnifiedAI constructor to return our duplicate
+    monkeypatch.setattr("unified_ai.UnifiedAI", lambda *a, **k: duplicate)
+
+    replicator = SystemReplicator(engine, token="t")
+    result = await replicator.duplicate_local()
+
+    duplicate.connect.assert_awaited_once()
+    duplicate.initialize.assert_awaited_once()
+    duplicate.brain.store_memory.assert_awaited_with("k", "v")
+    duplicate.feature_manager.enable.assert_called_with("feat")
+    assert result is duplicate
+
+
+@pytest.mark.asyncio
+async def test_duplicate_remote_sends(monkeypatch):
+    engine = UnifiedAI()
+    engine.optical.transfer_data = AsyncMock(return_value=True)
+    engine.brain.db = AsyncMock()  # avoid real DB
+
+    async def fake_snapshot(self):
+        return {"foo": "bar"}
+
+    monkeypatch.setattr(SystemReplicator, "_snapshot", fake_snapshot)
+    replicator = SystemReplicator(engine, token="t")
+    res = await replicator.duplicate_remote("channel")
+    engine.optical.transfer_data.assert_awaited()
+    assert res is True

--- a/unified_ai/__init__.py
+++ b/unified_ai/__init__.py
@@ -9,6 +9,7 @@ from .brain import BrainEngine
 from .optical import OpticalEngine
 from .aura import AuraEngine
 from .network_features import NetworkFeatureManager, NETWORK_FEATURES
+from .replicator import SystemReplicator
 
 
 class UnifiedAI:
@@ -73,3 +74,5 @@ async def lifespan(
         yield engine
     finally:
         await engine.close()
+
+__all__ = ["UnifiedAI", "lifespan", "SystemReplicator"]

--- a/unified_ai/replicator.py
+++ b/unified_ai/replicator.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import base64
+from typing import Any, Optional
+
+
+class SystemReplicator:
+    """Create duplicates of a running :class:`UnifiedAI` instance."""
+
+    def __init__(self, engine: "UnifiedAI", token: str = "replica", encryption_key: Optional[str] = None) -> None:
+        self.engine = engine
+        self.token = token
+        self.key = encryption_key.encode() if encryption_key else None
+
+    async def _snapshot(self) -> dict[str, Any]:
+        """Collect BrainEngine memories and enabled features."""
+        memories: list[dict[str, Any]] = []
+        async with self.engine.brain.db.execute(
+            "SELECT key, content, timestamp, access_count FROM memories"
+        ) as cursor:
+            async for row in cursor:
+                memories.append(
+                    {
+                        "key": row[0],
+                        "content": row[1],
+                        "timestamp": row[2],
+                        "access_count": row[3],
+                    }
+                )
+        return {"memories": memories, "features": list(self.engine.feature_manager.enabled)}
+
+    def _secure(self, data: Any) -> str:
+        payload = json.dumps({"token": self.token, "data": data})
+        if not self.key:
+            return payload
+        encoded = payload.encode()
+        key = self.key
+        xored = bytes(b ^ key[i % len(key)] for i, b in enumerate(encoded))
+        return base64.b64encode(xored).decode()
+
+    async def duplicate_local(self) -> "UnifiedAI":
+        """Spawn a copy of the engine within the current process."""
+        from . import UnifiedAI
+
+        snapshot = await self._snapshot()
+        duplicate = UnifiedAI(self.engine.redis_url)
+        await duplicate.connect()
+        await duplicate.initialize()
+        for feat in snapshot["features"]:
+            duplicate.feature_manager.enable(feat)
+        for mem in snapshot["memories"]:
+            await duplicate.brain.store_memory(mem["key"], mem["content"])
+        await self.engine.optical.transfer_data(self._secure({"status": "spawned"}), f"sync:{self.token}")
+        return duplicate
+
+    async def duplicate_remote(self, url: str) -> bool:
+        """Send a snapshot to a remote listener via the OpticalEngine."""
+        snapshot = await self._snapshot()
+        return await self.engine.optical.transfer_data(self._secure(snapshot), url)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Replicate a UnifiedAI instance")
+    parser.add_argument("--remote", help="Remote host channel")
+    parser.add_argument("--token", default="replica", help="Authentication token")
+    parser.add_argument("--key", help="Optional encryption key")
+    return parser.parse_args()
+
+
+def main() -> None:
+    from . import UnifiedAI
+
+    args = _parse_args()
+    engine = UnifiedAI()
+    replicator = SystemReplicator(engine, token=args.token, encryption_key=args.key)
+
+    async def run() -> None:
+        await engine.connect()
+        await engine.initialize()
+        if args.remote:
+            await replicator.duplicate_remote(args.remote)
+        else:
+            await replicator.duplicate_local()
+
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a `SystemReplicator` class with local/remote duplication
- expose CLI entry point and export from `__init__`
- document replicator usage
- test replicator behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ef08e1350832eaf4cad6e710c7e64