### PR TITLE
Add UnifiedAI FastAPI runner and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ WebGPT is a vanilla JS and HTML implementation of a transformer model, intended 
 
 ## UnifiedAI Example
 
-The repository also contains an example Python implementation of a modular AI system named **UnifiedAI**. See [`UnifiedAI.md`](UnifiedAI.md) for details and `unifiedai.py` for the source code. The example exposes `/query`, `/health`, and `/metrics` endpoints via FastAPI and includes a `NetworkFeatureManager` for optional networking capabilities.
-=======
 The repository also contains an example Python implementation of a modular AI system named **UnifiedAI**. See [`UnifiedAI.md`](UnifiedAI.md) for details and the `unified_ai` package for the source code. The example exposes `/query`, `/health`, and `/metrics` endpoints via FastAPI and includes a `NetworkFeatureManager` for optional networking capabilities. Our guiding principles are outlined in [DECLARATION.md](DECLARATION.md).
 
 ### Current Stats
@@ -110,7 +108,7 @@ the memory system. You can find it in `datasheets/optical_engine_datasheet.json`
    ```
 2. Start the UnifiedAI API:
    ```bash
-   python unifiedai.py
+   python -m unified_ai
    ```
 3. Launch the SRE chat GUI:
    ```bash
@@ -120,7 +118,7 @@ the memory system. You can find it in `datasheets/optical_engine_datasheet.json`
    ```bash
    pytest
    ```
-=======
+
 ## Running Tests
 
 Install dependencies first:

--- a/UnifiedAI.md
+++ b/UnifiedAI.md
@@ -29,11 +29,6 @@ UnifiedAI is a modular architecture that combines four engines to provide empath
 - **BrainEngine** – stores memories in SQLite, applies rule-based reasoning, and learns from interactions.
 - **OpticalEngine** – publishes events through Redis with optional networking features like smart packet shaping.
 - **AuraEngine** – validates output against rules loaded from `ethics_rules.json` for ethical compliance.
-=======
-- **SoulEngine** – detects sentiment in user messages and crafts human‑like replies.
-- **BrainEngine** – stores memories in SQLite and performs simple reasoning based on past interactions.
-- **OpticalEngine** – communicates through Redis channels to broadcast events.
-- **AuraEngine** – checks messages for forbidden content to enforce basic ethical rules.
 
 The orchestrator coordinates these engines so that input flows through AuraEngine for validation, then SoulEngine and BrainEngine to generate a reply, while OpticalEngine publishes logs asynchronously.
 
@@ -50,11 +45,8 @@ The orchestrator coordinates these engines so that input flows through AuraEngin
    ```
 4. Interact with the system using `curl` or any HTTP client:
    ```bash
-=======
    curl -X POST "http://localhost:8000/query" \
         -H "Content-Type: application/json" -d '{"query": "Hello there"}'
-   curl -X POST -H "Content-Type: application/json" \
-        -d '{"message": "Hello there"}' http://localhost:8000/chat
    ```
 
 The request is processed asynchronously. The reply contains an empathetic acknowledgement, demonstrates memory use and the message is published to Redis.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import unified_ai.__main__ as api  # noqa: E402
+from unified_ai import UnifiedAI
+
+
+@pytest.mark.asyncio
+async def test_api_endpoints(monkeypatch):
+    engine = UnifiedAI()
+    engine.interact = AsyncMock(return_value="reply")
+    engine.redis.ping = AsyncMock(return_value=True)
+    engine.brain.memory_count = AsyncMock(return_value=5)
+    engine.list_enabled_features = lambda: ["net"]
+
+    @asynccontextmanager
+    async def fake_engine_lifespan(app=None, engine_param=None):
+        yield engine
+
+    monkeypatch.setattr(api, "engine_lifespan", fake_engine_lifespan)
+
+    with TestClient(api.app) as client:
+        resp = client.post("/query", json={"query": "hi"})
+        assert resp.status_code == 200
+        assert resp.json() == {"response": "reply"}
+
+        health = client.get("/health").json()
+        assert health == {"redis": True, "features": ["net"]}
+
+        metrics = client.get("/metrics").json()
+        assert metrics == {"memory_count": 5, "network_features": ["net"]}

--- a/unified_ai/__main__.py
+++ b/unified_ai/__main__.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException, Request
+from contextlib import asynccontextmanager
+import uvicorn
+
+from . import lifespan as engine_lifespan, UnifiedAI
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # reuse the package lifespan but store the engine on app.state
+    async with engine_lifespan(app=app) as engine:
+        app.state.engine = engine
+        yield
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.post("/query")
+async def query(payload: dict, request: Request):
+    text = payload.get("query")
+    if not text:
+        raise HTTPException(status_code=400, detail="'query' field required")
+    engine: UnifiedAI = request.app.state.engine
+    result = await engine.interact(text)
+    return {"response": result}
+
+
+@app.get("/health")
+async def health(request: Request):
+    engine: UnifiedAI = request.app.state.engine
+    try:
+        redis_ok = await engine.redis.ping()
+    except Exception:
+        redis_ok = False
+    return {"redis": redis_ok, "features": engine.list_enabled_features()}
+
+
+@app.get("/metrics")
+async def metrics(request: Request):
+    engine: UnifiedAI = request.app.state.engine
+    count = await engine.brain.memory_count()
+    return {"memory_count": count, "network_features": engine.list_enabled_features()}
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- create `unified_ai/__main__.py` that exposes a FastAPI app
- document running the API with `python -m unified_ai`
- clean up doc merge artifacts
- add tests covering the new endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fc5a98014832ebabc097afe162d4d