### PR TITLE
Add unified_ai entrypoint module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ WebGPT is a vanilla JS and HTML implementation of a transformer model, intended 
 
 ## UnifiedAI Example
 
-The repository also contains an example Python implementation of a modular AI system named **UnifiedAI**. See [`UnifiedAI.md`](UnifiedAI.md) for details and `unifiedai.py` for the source code. The example exposes `/query`, `/health`, and `/metrics` endpoints via FastAPI and includes a `NetworkFeatureManager` for optional networking capabilities.
+The repository also contains an example Python implementation of a modular AI system named **UnifiedAI**. See [`UnifiedAI.md`](UnifiedAI.md) for details and the `unified_ai` package for the source code. The example exposes `/query`, `/health`, and `/metrics` endpoints via FastAPI and includes a `NetworkFeatureManager` for optional networking capabilities.
 =======
 The repository also contains an example Python implementation of a modular AI system named **UnifiedAI**. See [`UnifiedAI.md`](UnifiedAI.md) for details and the `unified_ai` package for the source code. The example exposes `/query`, `/health`, and `/metrics` endpoints via FastAPI and includes a `NetworkFeatureManager` for optional networking capabilities. Our guiding principles are outlined in [DECLARATION.md](DECLARATION.md).
 
@@ -110,7 +110,7 @@ the memory system. You can find it in `datasheets/optical_engine_datasheet.json`
    ```
 2. Start the UnifiedAI API:
    ```bash
-   python unifiedai.py
+   python -m unified_ai
    ```
 3. Launch the SRE chat GUI:
    ```bash

--- a/unified_ai/__main__.py
+++ b/unified_ai/__main__.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from fastapi import FastAPI, HTTPException, Request
+from pydantic import BaseModel
+import uvicorn
+
+from . import UnifiedAI, lifespan
+
+engine = UnifiedAI()
+
+@asynccontextmanager
+async def app_lifespan(app: FastAPI):
+    async with lifespan(app=app, engine=engine):
+        app.state.engine = engine
+        yield
+
+app = FastAPI(lifespan=app_lifespan)
+
+class QueryModel(BaseModel):
+    query: str
+
+@app.post("/query")
+async def query_endpoint(payload: QueryModel, request: Request):
+    ai: UnifiedAI = request.app.state.engine
+    try:
+        response = await ai.interact(payload.query)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"response": response}
+
+@app.get("/health")
+async def health_endpoint(request: Request):
+    ai: UnifiedAI = request.app.state.engine
+    redis_ok = await ai.redis.ping()
+    return {"redis": bool(redis_ok), "features": ai.list_enabled_features()}
+
+@app.get("/metrics")
+async def metrics_endpoint(request: Request):
+    ai: UnifiedAI = request.app.state.engine
+    mem_count = await ai.brain.memory_count()
+    return {"memory_count": mem_count, "enabled_features": ai.list_enabled_features()}
+
+def main() -> None:
+    uvicorn.run("unified_ai.__main__:app", host="0.0.0.0", port=8000)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expose a `__main__` module for unified_ai
- run FastAPI with lifespan context and add `/query`, `/health`, `/metrics` routes
- run API via `python -m unified_ai`
- update README to reflect new invocation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fcbb89a6c832eb5c54916298637d7