### PR TITLE
Document Android target and control scheme for Wizard War I

### DIFF
--- a/WizardWarI/README.md
+++ b/WizardWarI/README.md
@@ -8,6 +8,16 @@ This directory contains a minimal skeleton for an Unreal Engine project. It does
 * Each arm can hold a chain of tokens for dual wielding.
 * Tokens are acquired through combat and target practice.
 
+## Android Multiplayer Controls
+
+Wizard War I can be deployed to Android as a static first-person multiplayer experience.  Players remain stationary and interact through three on-screen buttons:
+
+* **Left Arm** – cast the currently equipped left-hand spell chain.
+* **Right Arm** – cast the currently equipped right-hand spell chain.
+* **Shield** – raise the configured shield chain to mitigate incoming damage.
+
+All other gameplay systems and rules described below remain unchanged.
+
 
 
 

--- a/WizardWarI/WizardWarI.uproject
+++ b/WizardWarI/WizardWarI.uproject
@@ -3,6 +3,10 @@
     "EngineAssociation": "5.0",
     "Category": "Games",
     "Description": "Wizard War I - Spell combat game skeleton",
+    "TargetPlatforms": [
+        "Android",
+        "Win64"
+    ],
     "Modules": [
         {
             "Name": "WizardWarI",


### PR DESCRIPTION
## Summary
- document Android build with static first-person controls and three-button spellcasting
- add Android to target platforms in project file

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896964bd2fc832ea41f6bf7b41d3c55