### PR TITLE
Add WWI-themed game engine with memory-aware asset loading

### DIFF
--- a/tests/test_wwi_engine.py
+++ b/tests/test_wwi_engine.py
@@ -1,0 +1,9 @@
+from wwi_engine.game_engine import GameEngine
+
+
+def test_asset_quality_degrades_when_memory_low():
+    engine = GameEngine(max_memory_bytes=6 * 1024 ** 2)  # 6MB limit
+    quality = engine.load_asset("biplane", quality="high")
+    assert quality == "low"
+    summary = engine.summary()
+    assert summary["asset_memory"] <= engine.max_memory_bytes

--- a/wwi_engine/__init__.py
+++ b/wwi_engine/__init__.py
@@ -1,0 +1,5 @@
+"""WWI-themed minimal game engine package."""
+
+from .game_engine import GameEngine
+
+__all__ = ["GameEngine"]

--- a/wwi_engine/game_engine.py
+++ b/wwi_engine/game_engine.py
@@ -1,0 +1,81 @@
+"""Simple WWI-themed game engine with memory constraints."""
+from __future__ import annotations
+
+import resource
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class Asset:
+    name: str
+    data: bytearray
+    quality: str
+
+
+@dataclass
+class GameEngine:
+    """A minimal game engine enforcing a memory ceiling.
+
+    The engine simulates asset loading and automatically degrades
+    asset quality when loading high quality assets would exceed the
+    configured memory limit.
+    """
+
+    max_memory_bytes: int = 4 * 1024 ** 3  # 4GB by default
+    assets: List[Asset] = field(default_factory=list)
+
+    HIGH_RES_SIZE: int = 10 * 1024 ** 2  # 10MB per high-res asset
+    LOW_RES_SIZE: int = 1 * 1024 ** 2   # 1MB per low-res asset
+
+    def _current_memory(self) -> int:
+        """Return current memory used by assets in bytes."""
+        return sum(len(asset.data) for asset in self.assets)
+
+    def _system_memory(self) -> int:
+        """Return the resident set size of the current process."""
+        usage = resource.getrusage(resource.RUSAGE_SELF)
+        # ru_maxrss is kilobytes on Linux
+        return usage.ru_maxrss * 1024
+
+    def _within_limit(self) -> bool:
+        return self._current_memory() <= self.max_memory_bytes
+
+    def load_asset(self, name: str, quality: str = "high") -> str:
+        """Load an asset, degrading quality if necessary.
+
+        Parameters
+        ----------
+        name: str
+            Name of the asset.
+        quality: str
+            Requested quality level ("high" or "low").
+
+        Returns
+        -------
+        str
+            Actual quality level used after potential degradation.
+        """
+
+        size = self.HIGH_RES_SIZE if quality == "high" else self.LOW_RES_SIZE
+        self.assets.append(Asset(name=name, data=bytearray(size), quality=quality))
+
+        if not self._within_limit():
+            # If exceeding limit with high quality, degrade to low quality
+            if quality == "high":
+                self.assets.pop()
+                return self.load_asset(name, quality="low")
+            # Low quality still exceeds limit -> clean up and raise
+            self.assets.pop()
+            raise MemoryError("Memory limit exceeded even with low quality asset")
+
+        return quality
+
+    def summary(self) -> Dict[str, int]:
+        """Return a summary of loaded assets and memory usage."""
+        return {
+            "asset_count": len(self.assets),
+            "asset_memory": self._current_memory(),
+            "process_memory": self._system_memory(),
+            "max_memory": self.max_memory_bytes,
+        }

--- a/wwi_engine/gui_workshop.py
+++ b/wwi_engine/gui_workshop.py
@@ -1,0 +1,46 @@
+"""Tkinter-based GUI workshop for building WWI-themed scenes."""
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import messagebox
+
+from .game_engine import GameEngine
+
+
+class WWIWorkshop(tk.Tk):
+    """GUI for assembling WWI scenes using :class:`GameEngine`."""
+
+    def __init__(self, engine: GameEngine | None = None):
+        super().__init__()
+        self.title("WWI Workshop")
+        self.engine = engine or GameEngine()
+        self.status_var = tk.StringVar(value="Ready")
+
+        self._build_menu()
+        self._build_status()
+
+    def _build_menu(self) -> None:
+        menu = tk.Menu(self)
+        self.config(menu=menu)
+
+        asset_menu = tk.Menu(menu, tearoff=0)
+        asset_menu.add_command(label="Add Trench", command=lambda: self._add_asset("trench"))
+        asset_menu.add_command(label="Add Biplane", command=lambda: self._add_asset("biplane"))
+        asset_menu.add_command(label="Add Tank", command=lambda: self._add_asset("tank"))
+        menu.add_cascade(label="Assets", menu=asset_menu)
+
+    def _build_status(self) -> None:
+        status_bar = tk.Label(self, textvariable=self.status_var, bd=1, relief=tk.SUNKEN, anchor=tk.W)
+        status_bar.pack(side=tk.BOTTOM, fill=tk.X)
+
+    def _add_asset(self, name: str) -> None:
+        try:
+            quality = self.engine.load_asset(name)
+            self.status_var.set(f"Added {name} in {quality} quality")
+        except MemoryError:
+            messagebox.showerror("Memory Limit", "Cannot add asset; memory limit reached.")
+
+
+if __name__ == "__main__":
+    workshop = WWIWorkshop()
+    workshop.mainloop()


### PR DESCRIPTION
## Summary
- add minimal GameEngine enforcing 4GB memory limit and degrading asset quality
- create Tkinter-based WWI Workshop GUI for adding scene assets
- test asset quality degradation when memory limit is low

## Testing
- `PYTHONPATH=. pytest tests/test_wwi_engine.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite'; RuntimeError: httpx required)*

------
https://chatgpt.com/codex/tasks/task_e_689a591904e4832ea3d690c7347aacfa