### PR TITLE
Add WWI game engine with physics and lighting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pydantic
 textblob
 vaderSentiment
 spacy
+psutil
 =======
 =======
 pytest

--- a/tests/test_wwi_engine.py
+++ b/tests/test_wwi_engine.py
@@ -1,0 +1,26 @@
+import pytest
+
+from wwi_engine.game_engine import GameEngine
+
+
+def test_asset_quality_degrades_when_memory_low():
+    engine = GameEngine(max_memory_bytes=6 * 1024 ** 2)  # 6MB limit
+    quality = engine.load_asset("biplane", quality="high")
+    assert quality == "low"
+    summary = engine.summary()
+    assert summary["asset_memory"] <= engine.max_memory_bytes
+
+
+def test_physics_step_moves_object():
+    engine = GameEngine()
+    engine.add_physics_object("crate", position=(0.0, 10.0))
+    engine.step_physics(1.0)
+    obj = engine.physics_objects[0]
+    assert obj.position[1] == pytest.approx(0.19, rel=1e-2)
+
+
+def test_light_intensity_uses_inverse_square():
+    engine = GameEngine()
+    engine.add_light((0.0, 0.0), 100.0)
+    intensity = engine.compute_lighting((0.0, 10.0))
+    assert intensity == pytest.approx(1.0, rel=1e-3)

--- a/wwi_engine/__init__.py
+++ b/wwi_engine/__init__.py
@@ -1,0 +1,5 @@
+"""WWI-themed minimal game engine package."""
+
+from .game_engine import GameEngine
+
+__all__ = ["GameEngine"]

--- a/wwi_engine/game_engine.py
+++ b/wwi_engine/game_engine.py
@@ -1,0 +1,156 @@
+"""Simple WWI-themed game engine with memory constraints."""
+from __future__ import annotations
+
+import psutil
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
+
+
+@dataclass
+class Asset:
+    name: str
+    data: bytearray
+    quality: str
+
+
+@dataclass
+class PhysicsObject:
+    """Simple physics body tracked by the engine."""
+
+    name: str
+    position: List[float]
+    velocity: List[float]
+    mass: float = 1.0
+
+
+@dataclass
+class Light:
+    """Point light with an intensity value."""
+
+    position: Tuple[float, float]
+    intensity: float
+
+
+@dataclass
+class GameEngine:
+    """A minimal game engine with memory, physics and lighting.
+
+    The engine simulates asset loading and automatically degrades
+    asset quality when loading high quality assets would exceed the
+    configured memory limit.  It also maintains a list of physics
+    bodies affected by gravity and point lights for simple lighting
+    calculations.
+    """
+
+    max_memory_bytes: int = 4 * 1024 ** 3  # 4GB by default
+    assets: List[Asset] = field(default_factory=list)
+    physics_objects: List[PhysicsObject] = field(default_factory=list)
+    lights: List[Light] = field(default_factory=list)
+    gravity: float = 9.81
+
+    HIGH_RES_SIZE: int = 10 * 1024 ** 2  # 10MB per high-res asset
+    LOW_RES_SIZE: int = 1 * 1024 ** 2   # 1MB per low-res asset
+
+    def _current_memory(self) -> int:
+        """Return current memory used by assets in bytes."""
+        return sum(len(asset.data) for asset in self.assets)
+
+    def _system_memory(self) -> int:
+        """Return the resident set size of the current process."""
+        process = psutil.Process()
+        return process.memory_info().rss
+
+    def _within_limit(self) -> bool:
+        return self._current_memory() <= self.max_memory_bytes
+
+    def load_asset(self, name: str, quality: str = "high") -> str:
+        """Load an asset, degrading quality if necessary.
+
+        Parameters
+        ----------
+        name: str
+            Name of the asset.
+        quality: str
+            Requested quality level ("high" or "low").
+
+        Returns
+        -------
+        str
+            Actual quality level used after potential degradation.
+        """
+
+        size = self.HIGH_RES_SIZE if quality == "high" else self.LOW_RES_SIZE
+        self.assets.append(Asset(name=name, data=bytearray(size), quality=quality))
+
+        if not self._within_limit():
+            # If exceeding limit with high quality, degrade to low quality
+            if quality == "high":
+                self.assets.pop()
+                return self.load_asset(name, quality="low")
+            # Low quality still exceeds limit -> clean up and raise
+            self.assets.pop()
+            raise MemoryError("Memory limit exceeded even with low quality asset")
+
+        return quality
+
+    # ------------------------------------------------------------------
+    # Physics
+    # ------------------------------------------------------------------
+    def add_physics_object(
+        self,
+        name: str,
+        position: Tuple[float, float],
+        velocity: Tuple[float, float] = (0.0, 0.0),
+        mass: float = 1.0,
+    ) -> PhysicsObject:
+        """Register a new physics body in the world."""
+
+        obj = PhysicsObject(name, list(position), list(velocity), mass)
+        self.physics_objects.append(obj)
+        return obj
+
+    def step_physics(self, dt: float) -> None:
+        """Advance the physics simulation by ``dt`` seconds."""
+
+        for obj in self.physics_objects:
+            # Apply gravity in the negative Y direction
+            obj.velocity[1] -= self.gravity * dt
+            obj.position[0] += obj.velocity[0] * dt
+            obj.position[1] += obj.velocity[1] * dt
+
+    # ------------------------------------------------------------------
+    # Lighting
+    # ------------------------------------------------------------------
+    def add_light(self, position: Tuple[float, float], intensity: float) -> Light:
+        """Add a point light to the scene."""
+
+        light = Light(position, intensity)
+        self.lights.append(light)
+        return light
+
+    def compute_lighting(self, point: Tuple[float, float]) -> float:
+        """Return the combined light intensity at ``point``.
+
+        Uses a simple inverse-square law for attenuation.
+        """
+
+        total = 0.0
+        for light in self.lights:
+            dx = point[0] - light.position[0]
+            dy = point[1] - light.position[1]
+            dist_sq = dx * dx + dy * dy
+            if dist_sq == 0:
+                # If the point is on the light, avoid division by zero
+                total += light.intensity
+            else:
+                total += light.intensity / dist_sq
+        return total
+
+    def summary(self) -> Dict[str, int]:
+        """Return a summary of loaded assets and memory usage."""
+        return {
+            "asset_count": len(self.assets),
+            "asset_memory": self._current_memory(),
+            "process_memory": self._system_memory(),
+            "max_memory": self.max_memory_bytes,
+        }

--- a/wwi_engine/gui_workshop.py
+++ b/wwi_engine/gui_workshop.py
@@ -1,0 +1,70 @@
+"""Tkinter-based GUI workshop for building WWI-themed scenes."""
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import messagebox
+
+from .game_engine import GameEngine
+
+
+class WWIWorkshop(tk.Tk):
+    """GUI for assembling WWI scenes using :class:`GameEngine`."""
+
+    def __init__(self, engine: GameEngine | None = None):
+        super().__init__()
+        self.title("WWI Workshop")
+        self.engine = engine or GameEngine()
+        self.status_var = tk.StringVar(value="Ready")
+
+        self._build_menu()
+        self._build_status()
+
+    def _build_menu(self) -> None:
+        menu = tk.Menu(self)
+        self.config(menu=menu)
+
+        asset_menu = tk.Menu(menu, tearoff=0)
+        asset_menu.add_command(label="Add Trench", command=lambda: self._add_asset("trench"))
+        asset_menu.add_command(label="Add Biplane", command=lambda: self._add_asset("biplane"))
+        asset_menu.add_command(label="Add Tank", command=lambda: self._add_asset("tank"))
+        menu.add_cascade(label="Assets", menu=asset_menu)
+
+        light_menu = tk.Menu(menu, tearoff=0)
+        light_menu.add_command(label="Add Light", command=self._add_light)
+        menu.add_cascade(label="Lighting", menu=light_menu)
+
+        physics_menu = tk.Menu(menu, tearoff=0)
+        physics_menu.add_command(label="Drop Crate", command=self._add_crate)
+        physics_menu.add_command(label="Step Physics", command=self._step_physics)
+        menu.add_cascade(label="Physics", menu=physics_menu)
+
+    def _build_status(self) -> None:
+        status_bar = tk.Label(self, textvariable=self.status_var, bd=1, relief=tk.SUNKEN, anchor=tk.W)
+        status_bar.pack(side=tk.BOTTOM, fill=tk.X)
+
+    def _add_asset(self, name: str) -> None:
+        try:
+            quality = self.engine.load_asset(name)
+            self.status_var.set(f"Added {name} in {quality} quality")
+        except MemoryError:
+            messagebox.showerror("Memory Limit", "Cannot add asset; memory limit reached.")
+
+    def _add_light(self) -> None:
+        self.engine.add_light((0.0, 0.0), 100.0)
+        self.status_var.set("Added light at origin")
+
+    def _add_crate(self) -> None:
+        self.engine.add_physics_object("crate", position=(0.0, 10.0))
+        self.status_var.set("Dropped crate from height 10")
+
+    def _step_physics(self) -> None:
+        self.engine.step_physics(1.0)
+        if self.engine.physics_objects:
+            y = self.engine.physics_objects[0].position[1]
+            self.status_var.set(f"Physics stepped; crate y={y:.2f}")
+
+
+
+if __name__ == "__main__":
+    workshop = WWIWorkshop()
+    workshop.mainloop()


### PR DESCRIPTION
## Summary
- extend GameEngine with simple physics bodies and point lights
- expand Tkinter WWI Workshop to add lights and step physics simulation
- test gravity effects on objects and inverse-square lighting
- use psutil for process memory tracking

## Testing
- `PYTHONPATH=. python -m pytest tests/test_wwi_engine.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'redis', 'fastapi', 'textblob')*

------
https://chatgpt.com/codex/tasks/task_e_689a591904e4832ea3d690c7347aacfa