### PR TITLE
Ignore jars and document Gradle wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Ignore build artifacts
+*.jar
+*.apk
+
+# Gradle wrapper files that should be generated automatically
+**/gradle-wrapper.jar
+
+# Generic build directories
+build/
+**/build/

--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ prompts = get_prompts('es')
 ```
 
 The default language is English if an unknown code is provided.
+
+## Gradle Wrapper
+
+If you use the optional Gradle-based tooling in this repository, run `./gradlew` after cloning. The wrapper will automatically download `gradle-wrapper.jar` and continue executing your command. The JAR file is not tracked in version control, so the download happens the first time you run the wrapper.


### PR DESCRIPTION
## Summary
- create `.gitignore` to exclude build artifacts like JARs, APKs and build dirs
- document how the Gradle wrapper automatically downloads `gradle-wrapper.jar` on first run

## Testing
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_68609057c810832e9de4e4393f992528